### PR TITLE
fix: transformed set to list for JSON dump to work properly

### DIFF
--- a/CntxtJS.py
+++ b/CntxtJS.py
@@ -734,7 +734,8 @@ class JSCodeKnowledgeGraph:
             },
             "function_params": self.function_params,
             "function_returns": self.function_returns,
-            "class_methods": self.class_methods,
+            # Convert sets to lists that are JSON serializable:
+            "class_methods": {k: list(v) for k, v in self.class_methods.items()},  
         }
 
         with open(output_path, "w", encoding="utf-8") as f:


### PR DESCRIPTION
## What this PR does

This fixes a small issue I encountered, generating a JSON graph for a large NodeJS Typescript codebase.
The initial error: `Error: Object of type set is not JSON serializable`

According to Claude 3.5's analysis: 
```text
The error message indicates that there is an attempt to serialize a Python set object into JSON, 
which is not directly supported by the json module.
To fix this, you need to convert the set objects to a JSON-serializable format, such as a list, before saving them
```
### What changed

made a change to convert **class_methods** sets to lists that are JSON serializable

### What I tested

- [x] Tested generating the graph for the codebase again, all went fine. Class methods were generated successfully.


### Result
Here is a partial preview of what was generated:
```JSON
   ...
    "Function: canUseEngine (File: src/helpers/usageGuard.ts)": "boolean"
    },
    "class_methods": {
      "Class: Schema (File: src/utils/schema.ts)": [
        "constructor"
      ],
      "Class: InternalServerError (File: src/utils/errors.ts)": [
        "super"
      ],
      "Class: TaskManager (File: src/utils/logger.ts)": [
        "TaskManagerFactory",
        "constructor"
      ],
      "Class: Embedder (File: src/helpers/embedder.ts)": [
        "embed"
      ],
      "Class: UsageService (File: src/services/usageService.ts)": [
        "constructor"
      ]
    }
```

Let me know if you need anything